### PR TITLE
refactor: use native `quarto.doc.has_bootstrap()`

### DIFF
--- a/_extensions/panel-accordion/panel-accordion.lua
+++ b/_extensions/panel-accordion/panel-accordion.lua
@@ -228,29 +228,8 @@ function render_icon(icon_attr)
   end
 end
 
-function has_bootstrap()
-  if not quarto.format.is_html_output() then
-    return false
-  end
-
-  local paramsText = os.getenv("QUARTO_FILTER_PARAMS")
-  if paramsText == nil or paramsText == "" then
-    return false
-  end
-
-  local paramsJson = quarto.base64.decode(paramsText)
-  local quartoParams = quarto.json.decode(paramsJson)
-
-  local value = quartoParams["has-bootstrap"]
-  if value == nil then
-    return false
-  end
-
-  return value
-end
-
 function Div(div)
-  if not has_bootstrap() then
+  if not quarto.doc.has_bootstrap() then
     return div
   end
 

--- a/_extensions/panel-accordion/panel-accordion.lua
+++ b/_extensions/panel-accordion/panel-accordion.lua
@@ -43,7 +43,6 @@
 > accordion items stay open when another item is opened.
 ]]
 
-local os = require("os")
 local accordion_idx = 1
 
 function parse_accordion_contents(div)


### PR DESCRIPTION
Replace the custom `has_bootstrap` function with the native `quarto.doc.has_bootstrap()` Lua API.

- https://quarto.org/docs/extensions/lua-api.html#format-detection